### PR TITLE
Bump pytest_httpserver version to 1.0.8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setuptools.setup(
             'requests',
             'urllib3>=1.26,<2.0',
             'pytest==7.2.1',
-            'pytest_httpserver==1.0.6',
+            'pytest_httpserver==1.0.8',
             'python-dotenv==1.0.0',
             'Werkzeug',
             'jsonpickle==3.0.1',


### PR DESCRIPTION
pytest_httpserver v1.0.6 is incompatible with werkzeug 2.3+. Either had to peg werkzeug back or bump pytest_httpserver