### PR TITLE
Add library info to supergood-bound headers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setuptools.setup(
         'jsonpickle',
         'urllib3>=1.26,<2.0',
         'requests',
-        'aiohttp==3.9.0b1',
+        'aiohttp',
         'pydash==7.0.1',
     ],
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.md', 'r') as fh:
 
 setuptools.setup(
     name='supergood',
-    version='1.0.20',
+    version='1.0.21',
     author='Alex Klarfeld',
     description='The Python client for Supergood',
     long_description=long_description,
@@ -24,7 +24,7 @@ setuptools.setup(
         'jsonpickle',
         'urllib3>=1.26,<2.0',
         'requests',
-        'aiohttp',
+        'aiohttp==3.9.0b1',
         'pydash==7.0.1',
     ],
     extras_require={

--- a/src/supergood/client.py
+++ b/src/supergood/client.py
@@ -44,7 +44,9 @@ class Client(object):
         header_options = {
                 'Accept' : 'application/json, text/plain, */*',
                 'Content-Type' : 'application/json',
-                'Authorization' : 'Basic ' + b64encode(bytes(authorization, 'utf-8')).decode('utf-8')
+                'Authorization' : 'Basic ' + b64encode(bytes(authorization, 'utf-8')).decode('utf-8'),
+                'supergood-api-type' : 'supergood-py',
+                'supergood-api-version' : version('supergood'),
             }
         self.config = DEFAULT_SUPERGOOD_CONFIG
         self.config.update(config)
@@ -87,11 +89,6 @@ class Client(object):
         # Don't log requests supergood is making to the event database
         if (host_domain != supergood_base_url and host_domain not in self.config['ignoredDomains']):
             parsed_url = urlparse(url)
-            injected_headers = dict(headers)
-            injected_headers.update({
-                'supergood-client-type': 'supergood-py',
-                'supergood-client-version': version('supergood'),
-            })
             try:
                 request = {
                     'request': {
@@ -99,7 +96,7 @@ class Client(object):
                         'method': method,
                         'url': url,
                         'body': redact_values(safe_parse_json(body), self.config['includedKeys'], self.config['ignoreRedaction']),
-                        'headers': redact_values(injected_headers, self.config['includedKeys'], self.config['ignoreRedaction']),
+                        'headers': redact_values(dict(headers), self.config['includedKeys'], self.config['ignoreRedaction']),
                         'path': parsed_url.path,
                         'search': parsed_url.query,
                         'requestedAt': now,

--- a/src/supergood/client.py
+++ b/src/supergood/client.py
@@ -45,7 +45,7 @@ class Client(object):
                 'Accept' : 'application/json, text/plain, */*',
                 'Content-Type' : 'application/json',
                 'Authorization' : 'Basic ' + b64encode(bytes(authorization, 'utf-8')).decode('utf-8'),
-                'supergood-api-type' : 'supergood-py',
+                'supergood-api' : 'supergood-py',
                 'supergood-api-version' : version('supergood'),
             }
         self.config = DEFAULT_SUPERGOOD_CONFIG

--- a/src/supergood/client.py
+++ b/src/supergood/client.py
@@ -16,6 +16,7 @@ from uuid import uuid4
 from datetime import datetime
 from base64 import b64encode
 from dotenv import load_dotenv
+from importlib.metadata import version
 from .logger import Logger
 from .api import Api
 from .constants import *
@@ -86,6 +87,11 @@ class Client(object):
         # Don't log requests supergood is making to the event database
         if (host_domain != supergood_base_url and host_domain not in self.config['ignoredDomains']):
             parsed_url = urlparse(url)
+            injected_headers = dict(headers)
+            injected_headers.update({
+                'supergood-client-type': 'supergood-py',
+                'supergood-client-version': version('supergood'),
+            })
             try:
                 request = {
                     'request': {
@@ -93,7 +99,7 @@ class Client(object):
                         'method': method,
                         'url': url,
                         'body': redact_values(safe_parse_json(body), self.config['includedKeys'], self.config['ignoreRedaction']),
-                        'headers': redact_values(dict(headers), self.config['includedKeys'], self.config['ignoreRedaction']),
+                        'headers': redact_values(injected_headers, self.config['includedKeys'], self.config['ignoreRedaction']),
                         'path': parsed_url.path,
                         'search': parsed_url.query,
                         'requestedAt': now,


### PR DESCRIPTION
This PR includes the library and library version in the header of requests being made to supergood. These are consumed on supergood's side and used for debugging.