### PR TITLE
add log{Request|Response}{Body|Headers} config params

### DIFF
--- a/src/supergood/client.py
+++ b/src/supergood/client.py
@@ -75,6 +75,8 @@ class Client(object):
                 daemon=True, target=self._get_config
             )
             self.remote_config_initial_pull.start()
+        else:
+            self.log.debug("auto config off. Remember to request manually")
 
         self.remote_config_refresh_thread = RepeatingThread(
             self._get_config, self.base_config["configInterval"] / 1000
@@ -99,6 +101,8 @@ class Client(object):
         self.flush_lock = Lock()
         if auto_flush:
             self.flush_thread.start()
+        else:
+            self.log.debug("auto flush off, remember to flush manually")
 
         # On clean exit, or terminated exit - exit gracefully
         atexit.register(self.close)
@@ -164,12 +168,22 @@ class Client(object):
             ):
                 now = datetime.now().isoformat()
                 parsed_url = urlparse(url)
+                filtered_body = (
+                    ""
+                    if not self.base_config["logRequestBody"]
+                    else safe_parse_json(safe_decode(body))
+                )
+                filtered_headers = (
+                    {}
+                    if (not self.base_config["logRequestHeaders"] or headers is None)
+                    else dict(headers)
+                )
                 request["request"] = {
                     "id": request_id,
                     "method": method,
                     "url": url,
-                    "body": safe_parse_json(safe_decode(body)),
-                    "headers": {} if headers is None else dict(headers),
+                    "body": filtered_body,
+                    "headers": filtered_headers,
                     "path": parsed_url.path,
                     "search": parsed_url.query,
                     "requestedAt": now,
@@ -195,10 +209,16 @@ class Client(object):
             # Ignored domains are not in the request cache, so this yields None
             request = self._request_cache.pop(request_id, None)
             if request:
-                decoded_body = safe_decode(response_body)
+                body = safe_parse_json(safe_decode(response_body))
+                filtered_body = "" if not self.base_config["logResponseBody"] else body
+                filtered_headers = (
+                    {}
+                    if not self.base_config["logResponseHeaders"]
+                    else dict(response_headers)
+                )
                 response = {
-                    "body": safe_parse_json(decoded_body),
-                    "headers": dict(response_headers),
+                    "body": filtered_body,
+                    "headers": filtered_headers,
                     "status": response_status,
                     "statusText": response_status_text,
                     "respondedAt": datetime.now().isoformat(),

--- a/src/supergood/constants.py
+++ b/src/supergood/constants.py
@@ -17,6 +17,10 @@ DEFAULT_SUPERGOOD_CONFIG = {
     "remoteConfigEndpoint": "/config",
     "ignoredDomains": [],
     "ignoreRedaction": False,
+    "logRequestHeaders": True,
+    "logRequestBody": True,
+    "logResponseHeaders": True,
+    "logResponseBody": True,
 }
 
 ERRORS = {

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -3,6 +3,10 @@ def get_config(
     ignored_domains=[],
     ignore_redaction=False,
     config_interval=10000,
+    log_request_body=True,
+    log_request_headers=True,
+    log_response_body=True,
+    log_response_headers=True,
 ):
     return {
         "flushInterval": flush_interval,
@@ -11,6 +15,10 @@ def get_config(
         "errorSinkEndpoint": "https://api.supergood.ai/errors",
         "ignoredDomains": ignored_domains,
         "ignoreRedaction": ignore_redaction,
+        "logRequestHeaders": log_request_headers,
+        "logRequestBody": log_request_body,
+        "logResponseHeaders": log_response_headers,
+        "logResponseBody": log_response_body,
     }
 
 

--- a/tests/test_dont_log.py
+++ b/tests/test_dont_log.py
@@ -1,0 +1,34 @@
+import pytest
+import requests
+
+from supergood.api import Api
+from tests.helper import get_config
+
+TEST_BED_URL = "http://supergood-testbed.herokuapp.com"
+
+
+class TestDontLog:
+    @pytest.mark.parametrize(
+        "supergood_client",
+        [
+            {
+                "config": get_config(
+                    log_request_body=False,
+                    log_request_headers=False,
+                    log_response_body=False,
+                    log_response_headers=False,
+                ),
+            }
+        ],
+        indirect=True,
+    )
+    def test_ignores_fields_when_set(self, supergood_client):
+        requests.get(f"{TEST_BED_URL}/200")
+        supergood_client.flush_cache()
+        supergood_client.kill()
+        args = Api.post_events.call_args[0][0]
+        assert len(args) == 1
+        assert args[0]["request"]["body"] == ""
+        assert args[0]["request"]["headers"] == {}
+        assert args[0]["response"]["body"] == ""
+        assert args[0]["response"]["headers"] == {}


### PR DESCRIPTION
Adds new parameters to the base (local) config. These parameters are, with defaults,
```python
"logRequestHeaders": True, 
"logRequestBody": True, 
"logResponseHeaders": True,
"logResponseBody": True,
```
Setting any of them to False will null out the value being sent to Supergood. While this limits SG's ability to do anomaly detection, we think it's a useful feature to allow users to be even more in control of their own data. 