### PR TITLE
redact by default

### DIFF
--- a/src/supergood/constants.py
+++ b/src/supergood/constants.py
@@ -16,11 +16,12 @@ DEFAULT_SUPERGOOD_CONFIG = {
     "errorSinkEndpoint": "/errors",
     "remoteConfigEndpoint": "/config",
     "ignoredDomains": [],
-    "ignoreRedaction": False,
-    "logRequestHeaders": True,
+    "defaultRedact": True,  # redact all payloads, ignore other flags
+    "logRequestHeaders": True,  # unless defaultRedact,
     "logRequestBody": True,
     "logResponseHeaders": True,
     "logResponseBody": True,
+    "ignoreRedaction": False,
 }
 
 ERRORS = {

--- a/src/supergood/constants.py
+++ b/src/supergood/constants.py
@@ -17,7 +17,7 @@ DEFAULT_SUPERGOOD_CONFIG = {
     "remoteConfigEndpoint": "/config",
     "ignoredDomains": [],
     "forceRedactAll": True,  # redact all payloads, ignore other flags
-    "logRequestHeaders": True,  # unless defaultRedact,
+    "logRequestHeaders": True,  # more fine-grained redaction for each of the request|response body|headers
     "logRequestBody": True,
     "logResponseHeaders": True,
     "logResponseBody": True,

--- a/src/supergood/constants.py
+++ b/src/supergood/constants.py
@@ -16,7 +16,7 @@ DEFAULT_SUPERGOOD_CONFIG = {
     "errorSinkEndpoint": "/errors",
     "remoteConfigEndpoint": "/config",
     "ignoredDomains": [],
-    "defaultRedact": True,  # redact all payloads, ignore other flags
+    "forceRedactAll": True,  # redact all payloads, ignore other flags
     "logRequestHeaders": True,  # unless defaultRedact,
     "logRequestBody": True,
     "logResponseHeaders": True,

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -7,6 +7,7 @@ def get_config(
     log_request_headers=True,
     log_response_body=True,
     log_response_headers=True,
+    force_redact_all=False,  # this is true by default in the config, but most tests want to test it off
 ):
     return {
         "flushInterval": flush_interval,
@@ -19,6 +20,7 @@ def get_config(
         "logRequestBody": log_request_body,
         "logResponseHeaders": log_response_headers,
         "logResponseBody": log_response_body,
+        "forceRedactAll": force_redact_all,
     }
 
 


### PR DESCRIPTION
New feature: redact by default.

When first installing supergood, it will, by default, not send payload values back to Supergood. It will send key metadata (path, type, size) back only. To send payload values back, you now have to set
`forceRedactAll: False`
Tested locally using simple and nested array responses