### PR TITLE
fix skey nesting for redact by default

### DIFF
--- a/src/supergood/helpers.py
+++ b/src/supergood/helpers.py
@@ -171,7 +171,9 @@ def redact_all(input_array):
                     actual = transform_key(key, "response.headers")
                     set_(data, actual, None)
                 skeys += new_skeys
-        data["metadata"] = skeys
+        if "metadata" not in data:
+            data["metadata"] = {}
+        data["metadata"].update({"sensitiveKeys": skeys})
 
 
 def deep_redact_(input, keypath, action):


### PR DESCRIPTION
redact by default does successfully redact by default, but breaks some upstream supergood functionalities because of a bug in nesting the sensitiveKeys within the metadata blob.

This PR nests the skeys correctly