### PR TITLE
Fix request headers unserializable

### DIFF
--- a/src/supergood/client.py
+++ b/src/supergood/client.py
@@ -166,7 +166,9 @@ class Client(object):
         try:
             url = safe_decode(url)  # we do this first so the urlparse isn't also bytes
             host_domain = urlparse(url).hostname
-            safe_headers = dict(headers)  # sometimes headers is not json serializable
+            safe_headers = (
+                {} if headers is None else dict(headers)
+            )  # sometimes headers is not json serializable
             request["metadata"] = {}
             # Check that we should cache the request
             if not self._should_ignore(

--- a/src/supergood/client.py
+++ b/src/supergood/client.py
@@ -166,6 +166,7 @@ class Client(object):
         try:
             url = safe_decode(url)  # we do this first so the urlparse isn't also bytes
             host_domain = urlparse(url).hostname
+            safe_headers = dict(headers)  # sometimes headers is not json serializable
             request["metadata"] = {}
             # Check that we should cache the request
             if not self._should_ignore(
@@ -173,7 +174,7 @@ class Client(object):
                 request["metadata"],  # we store endpoint id in metadata
                 url=url,
                 request_body=body,
-                request_headers=headers,
+                request_headers=safe_headers,
             ):
                 now = datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
                 parsed_url = urlparse(url)
@@ -185,7 +186,7 @@ class Client(object):
                 filtered_headers = (
                     {}
                     if (not self.base_config["logRequestHeaders"] or headers is None)
-                    else decode_headers(dict(headers))
+                    else decode_headers(safe_headers)
                 )
                 request["request"] = {
                     "id": request_id,

--- a/tests/caching/test_location_request_body.py
+++ b/tests/caching/test_location_request_body.py
@@ -16,8 +16,8 @@ from tests.helper import get_remote_config
     ],
     indirect=True,
 )
-class TestLocationRequestHeaders:
-    def test_request_headers(self, httpserver, supergood_client):
+class TestLocationRequestBody:
+    def test_request_body(self, httpserver, supergood_client):
         httpserver.expect_request("/200").respond_with_json(
             {
                 "string": "abc",

--- a/tests/caching/test_location_request_body.py
+++ b/tests/caching/test_location_request_body.py
@@ -1,0 +1,38 @@
+import pytest
+import requests
+
+from supergood.api import Api
+from tests.helper import get_remote_config
+
+
+@pytest.mark.parametrize(
+    "supergood_client",
+    [
+        {
+            "remote_config": get_remote_config(
+                action="Ignore", location="requestBody", regex="scoobydoo"
+            )
+        }
+    ],
+    indirect=True,
+)
+class TestLocationRequestHeaders:
+    def test_request_headers(self, httpserver, supergood_client):
+        httpserver.expect_request("/200").respond_with_json(
+            {
+                "string": "abc",
+            }
+        )
+        requests.request(
+            method="get",
+            url=httpserver.url_for("/200"),
+            data="blah scoobydoobydoo blah",
+        )
+        supergood_client.flush_cache()
+        assert Api.post_events.call_args is None
+        requests.request(
+            method="get", url=httpserver.url_for("/200"), data="blah scrappydootoo blah"
+        )
+        supergood_client.flush_cache()
+        args = Api.post_events.call_args[0][0]
+        assert len(args) == 1

--- a/tests/caching/test_location_request_headers.py
+++ b/tests/caching/test_location_request_headers.py
@@ -1,0 +1,32 @@
+import pytest
+import requests
+
+from supergood.api import Api
+from tests.helper import get_remote_config
+
+
+@pytest.mark.parametrize(
+    "supergood_client",
+    [
+        {
+            "remote_config": get_remote_config(
+                action="Ignore", location="requestHeaders", regex="scoobydoo"
+            )
+        }
+    ],
+    indirect=True,
+)
+class TestLocationRequestHeaders:
+    def test_request_headers(self, httpserver, supergood_client):
+        httpserver.expect_request("/200").respond_with_json(
+            {
+                "string": "abc",
+            }
+        )
+        requests.get(httpserver.url_for("/200"), headers={"X-test": "scoobydoo"})
+        supergood_client.flush_cache()
+        assert Api.post_events.call_args is None
+        requests.get(httpserver.url_for("/200"), headers={"X-test": "scrappydootoo"})
+        supergood_client.flush_cache()
+        args = Api.post_events.call_args[0][0]
+        assert len(args) == 1

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -28,7 +28,7 @@ def build_key(key_path, key_action="REDACT"):
     return {"keyPath": key_path, "action": key_action}
 
 
-def get_remote_config(action="Allow", keys=[]):
+def get_remote_config(action="Allow", keys=[], location="path", regex="200"):
     built_keys = list(map(lambda tup: build_key(tup[0], tup[1]), keys))
     return [
         {
@@ -37,7 +37,7 @@ def get_remote_config(action="Allow", keys=[]):
             "endpoints": [
                 {
                     "id": "endpoint-id",
-                    "matchingRegex": {"location": "path", "regex": "200"},
+                    "matchingRegex": {"location": location, "regex": regex},
                     "endpointConfiguration": {
                         "action": action,
                         "sensitiveKeys": built_keys,


### PR DESCRIPTION
During testing we'd overlooked test cases involving a `location` value of `requestHeaders/requestBody`. In some cases requestHeaders were not json serializable and we were seeing endpoint matching fail.

This PR fixes the unserializable headers by calling `dict()` on them, which seems to make them serializable.

It also adds 2 new test cases to ensure a location of `requestHeaders` and `requestBody` are successfully caught, as these two are weirder than matching to other locations because they involve a json dump