### PR TITLE
Support urllib3 v2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,17 +27,13 @@ setuptools.setup(
         "python-dotenv==1.0.0",
         "requests",
         "tldextract>=5",
-        "urllib3>=1.26,<2.0",
+        "urllib3>=2.0",
     ],
     extras_require={
         "test": [
-            "requests",
-            "urllib3>=1.26,<2.0",
             "pytest==7.2.1",
             "pytest_httpserver==1.0.8",
-            "python-dotenv==1.0.0",
             "Werkzeug",
-            "jsonpickle==3.0.1",
             "pytest-mock==3.10.0",
         ]
     },

--- a/src/supergood/vendors/urllib3.py
+++ b/src/supergood/vendors/urllib3.py
@@ -1,13 +1,18 @@
-import http
+import http.client
+from uuid import uuid4
 
 import urllib3
+import urllib3.connection
 
 from ..constants import REQUEST_ID_KEY
+
+HTTPS_PORT = http.client.HTTPS_PORT
 
 
 def patch(cache_request, cache_response):
     _original_read_chunked = urllib3.HTTPResponse.read_chunked
     _original_getheaders = http.client.HTTPResponse.getheaders
+    _original_request = urllib3.connection.HTTPConnection.request
 
     def _wrap_read_chunked(urllib3HttpResponse, amt=None, decode_content=None):
         response_object = urllib3HttpResponse._original_response
@@ -28,4 +33,13 @@ def patch(cache_request, cache_response):
             response_status_text=response_object.reason,
         )
 
+    def _wrap_request(http_connection, method, url, body=None, headers=None, **kwargs):
+        request_id = str(uuid4())
+        scheme = "https" if http_connection.port == HTTPS_PORT else "http"
+        request_url = f"{scheme}://{http_connection.host}{url}"
+        setattr(http_connection, REQUEST_ID_KEY, request_id)
+        cache_request(request_id, request_url, method, body, headers)
+        return _original_request(http_connection, method, url, body, headers, **kwargs)
+
     urllib3.HTTPResponse.read_chunked = _wrap_read_chunked
+    urllib3.connection.HTTPConnection.request = _wrap_request


### PR DESCRIPTION
the base `http.client.HTTPConnection` is not used by urllib3 v2, hence why it's a breaking change for this library. Instead we hook into it's `request` method on the urllib3 HTTPConnection. The response is captured while reading the returned HTTPResponse object, which is patched in http.py

There's a chance we could patch even lower down in the base `http` lib code that gets invoked here, but that would require a reasonable rewrite. From my investigation that would require
- patching HTTPConnection.{`putresponse` and `putheaders`} to make sure the url, method, and all of the headers are stored on the http connection in some supergood key/keys
- patching `HTTPConnection.send` to  build up the `data` fields into the entire request body, which requires building it up iteratively while waiting for an empty chunk to signal EOF

STILL TODO:
- streaming urllib3 (either doesn't get captured, or only the first streamed chunk is captured)