### PR TITLE
Set telemetry endpoint

### DIFF
--- a/src/supergood/api.py
+++ b/src/supergood/api.py
@@ -6,8 +6,14 @@ from .constants import *
 
 
 class Api(object):
-    def __init__(self, header_options, base_url=DEFAULT_SUPERGOOD_BASE_URL):
+    def __init__(
+        self,
+        header_options,
+        base_url=DEFAULT_SUPERGOOD_BASE_URL,
+        telemetry_url=DEFAULT_SUPERGOOD_TELEMETRY_URL,
+    ):
         self.base_url = base_url
+        self.telemetry_url = telemetry_url
         self.header_options = header_options
         self.event_sink_url = None
         self.error_sink_url = None
@@ -48,7 +54,7 @@ class Api(object):
 
     # Error posting
     def set_error_sink_url(self, endpoint):
-        self.error_sink_url = urljoin(self.base_url, endpoint)
+        self.error_sink_url = urljoin(self.telemetry_url, endpoint)
 
     def post_errors(self, data, exc_info, message):
         if not self.error_sink_url:

--- a/src/supergood/client.py
+++ b/src/supergood/client.py
@@ -38,10 +38,14 @@ class Client(object):
         client_id=os.getenv("SUPERGOOD_CLIENT_ID"),
         client_secret_id=os.getenv("SUPERGOOD_CLIENT_SECRET"),
         base_url=os.getenv("SUPERGOOD_BASE_URL"),
+        telemetry_url=os.getenv("SUPERGOOD_TELEMETRY_URL"),
         config={},
         metadata={},
     ):
         self.base_url = base_url if base_url else DEFAULT_SUPERGOOD_BASE_URL
+        self.telemetry_url = (
+            telemetry_url if telemetry_url else DEFAULT_SUPERGOOD_TELEMETRY_URL
+        )
 
         # By default will spin up threads to handle flushing and config fetching
         #  set the appropriate environment variable to override this behavior.
@@ -70,7 +74,7 @@ class Client(object):
         self.base_config = DEFAULT_SUPERGOOD_CONFIG
         self.base_config.update(config)
 
-        self.api = Api(header_options, self.base_url)
+        self.api = Api(header_options, self.base_url, self.telemetry_url)
         self.api.set_event_sink_url(self.base_config["eventSinkEndpoint"])
         self.api.set_error_sink_url(self.base_config["errorSinkEndpoint"])
         self.api.set_config_pull_url(self.base_config["remoteConfigEndpoint"])

--- a/src/supergood/constants.py
+++ b/src/supergood/constants.py
@@ -7,8 +7,8 @@ SIGNALS = [
 REQUEST_ID_KEY = "_supergood_request_id"
 GZIP_START_BYTES = b"\x1f\x8b"
 DEFAULT_SUPERGOOD_BYTE_LIMIT = 500000
-DEFAULT_SUPERGOOD_CONFIG_URL = "https://api.supergood.ai/config/"
 DEFAULT_SUPERGOOD_BASE_URL = "https://api.supergood.ai/"
+DEFAULT_SUPERGOOD_TELEMETRY_URL = "https://telemetry.supergood.ai"
 DEFAULT_SUPERGOOD_CONFIG = {
     "flushInterval": 1000,
     "configInterval": 10000,


### PR DESCRIPTION
report errors to the telemetry endpoint. We're separating out error reporting from event reporting for the purposes of flow control.