### PR TITLE
Add ability to flush during response cache for celery

### DIFF
--- a/src/supergood/client.py
+++ b/src/supergood/client.py
@@ -372,6 +372,7 @@ class Client(object):
                 self.api.post_events(data)
         except Exception:
             trace = "".join(traceback.format_exc())
+            payload = ""
             try:
                 urls = []
                 for entry in data:
@@ -382,7 +383,7 @@ class Client(object):
             except Exception:
                 # something is really messed up, just report out
                 payload = self._build_log_payload()
-                self.log.error(ERRORS["POSTING_EVENTS"], trace, payload)
+            self.log.error(ERRORS["POSTING_EVENTS"], trace, payload)
         finally:  # always occurs, even from internal returns
             for response_key in response_keys:
                 self._response_cache.pop(response_key, None)


### PR DESCRIPTION
The way celery forks the existing main process ends up being problematic for the supergood python client.

It makes a copy of all the in-memory items on the client, but does NOT copy over the threads running on the main thread. This means remote configs will not get updated in the background, and flushes won't occur in the background. There's a few ways we're thinking of addressing this.

In the short term:
This PR ensures that the forked celery worker will still report events to supergood. The downside is we can't make use of batching like we can in the main thread, but it was a quick option to ensure we don't miss events.

In the medium term:
we're thinking about utilizing disk writes on forked threads so we can bundle those up on either the main thread or in a sidecar agent. This will remove the synchronous redact and post from the celery worker and offload it to the main thread / sidecar which are more long-running

In the long term:
we're investigating eBPF solutions

Tested on a dummy django server with simple celery workers making http calls