### PR TITLE
Add telemetry endpoint

### DIFF
--- a/src/supergood/api.py
+++ b/src/supergood/api.py
@@ -18,9 +18,29 @@ class Api(object):
         self.event_sink_url = None
         self.error_sink_url = None
         self.config_pull_url = None
+        self.telemetry_post_url = None
 
     def set_logger(self, logger):
         self.log = logger
+
+    # Telemetry
+    def set_telemetry_post_url(self, endpoint):
+        self.telemetry_post_url = urljoin(self.telemetry_url, endpoint)
+
+    # Telemetry posts are treated more as fire and forget. If they fail, no big deal
+    #  this metadata primarily helps supergood debug remote issues, it's not used
+    #  for anomaly/usage monitoring
+    def post_telemetry(self, payload):
+        if not self.telemetry_post_url:
+            raise Exception(ERRORS["UNINITIALIZED"])
+        response = requests.post(
+            self.telemetry_post_url, json=payload, headers=self.header_options
+        )
+        if response.status_code == 401:
+            raise Exception(ERRORS["UNAUTHORIZED"])
+        if response.status_code != 200 and response.status_code != 201:
+            raise Exception(ERRORS["POSTING_TELEMETRY"])
+        return response.json()
 
     # Remote config fetching
     def set_config_pull_url(self, endpoint):

--- a/src/supergood/constants.py
+++ b/src/supergood/constants.py
@@ -15,6 +15,7 @@ DEFAULT_SUPERGOOD_CONFIG = {
     "eventSinkEndpoint": "/events",
     "errorSinkEndpoint": "/errors",
     "remoteConfigEndpoint": "/config",
+    "telemetryPostEndpoint": "/telemetry",
     "ignoredDomains": [],
     "forceRedactAll": False,  # redact all payloads, ignores other flags when set
     "logRequestHeaders": True,  # more fine-grained redaction for each of the request|response body|headers
@@ -40,4 +41,5 @@ ERRORS = {
     "UNKNOWN": "Client received unexpected value",
     "REDACTION": "Client failed to redact sensitive keys",
     "LOCK_STATE": "Client lock state ambiguous",
+    "POSTING_TELEMETRY": "Error posting telemetry",
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -60,6 +60,7 @@ def supergood_client(request, session_mocker, monkeysession):
     session_mocker.patch(
         "supergood.api.Api.get_config", return_value=remote_config
     ).start()
+    session_mocker.patch("supergood.api.Api.post_telemetry", return_value=None).start()
 
     if not auto:
         monkeysession.setenv("SG_OVERRIDE_AUTO_FLUSH", "false")


### PR DESCRIPTION
We're moving the error logs to a new telemetry endpoint, along with an additional telemetry print during flush to assist us in debugging remotely.