### PR TITLE
Support all versions of urllib3 and a few telemetry fixes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setuptools.setup(
         "python-dotenv==1.0.0",
         "requests",
         "tldextract>=5",
-        "urllib3>=2.0",
+        "urllib3",
     ],
     extras_require={
         "test": [

--- a/src/supergood/client.py
+++ b/src/supergood/client.py
@@ -147,10 +147,12 @@ class Client(object):
         request_headers=None,
     ):
         supergood_base_url = urlparse(self.base_url).hostname
+        supergood_telemetry_url = urlparse(self.telemetry_url).hostname
         # If we haven't fetched the remote config yet, always ignore
         if (
             self.remote_config is None
             or host_domain == supergood_base_url
+            or host_domain == supergood_telemetry_url
             or host_domain in self.base_config["ignoredDomains"]
         ):
             return True
@@ -362,8 +364,8 @@ class Client(object):
                 try:
                     self.api.post_telemetry(
                         {
-                            "numResponseCacheKeys": response_keys,
-                            "numRequestCacheKeys": request_keys,
+                            "numResponseCacheKeys": len(response_keys),
+                            "numRequestCacheKeys": len(request_keys),
                         }
                     )
                 except Exception as e:

--- a/src/supergood/vendors/urllib3.py
+++ b/src/supergood/vendors/urllib3.py
@@ -1,4 +1,5 @@
 import http.client
+from importlib.metadata import version
 from uuid import uuid4
 
 import urllib3
@@ -42,4 +43,6 @@ def patch(cache_request, cache_response):
         return _original_request(http_connection, method, url, body, headers, **kwargs)
 
     urllib3.HTTPResponse.read_chunked = _wrap_read_chunked
-    urllib3.connection.HTTPConnection.request = _wrap_request
+    if version("urllib3").startswith("2"):
+        # This only needs to be patched in urllib3 v2+
+        urllib3.connection.HTTPConnection.request = _wrap_request


### PR DESCRIPTION
After some consideration, while in general libraries should be moving toward urllib3 v2 support, for a library like ours it makes more sense to be inclusive where possible.

This PR undoes the decision to peg urllib3 to v2+, instead opting to go with whatever is decided from other dependencies. If it's urllib3 v1, the patch we need for v2 simply won't be applied.

This also takes a few other tweaks to telemetry out. One is to report the _number_ of keys instead of their uuids, and the other is a future proofing to not death loop if we decide to point telemetry at a different hostname in the future.