### PR TITLE
Add config flags to enable serverless supergood

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.1.6
+current_version = 1.1.7
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="supergood",
-    version="1.1.6",
+    version="1.1.7",
     author="Alex Klarfeld",
     description="The Python client for Supergood",
     long_description=long_description,

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="supergood",
-    version="1.1.7a0",
+    version="1.1.6",
     author="Alex Klarfeld",
     description="The Python client for Supergood",
     long_description=long_description,

--- a/src/supergood/constants.py
+++ b/src/supergood/constants.py
@@ -22,7 +22,9 @@ DEFAULT_SUPERGOOD_CONFIG = {
     "logRequestBody": True,
     "logResponseHeaders": True,
     "logResponseBody": True,
-    "ignoreRedaction": False,
+    "ignoreRedaction": False,  # ignores redaction. Lowest priority flag
+    "useRemoteConfig": True,
+    "runThreads": True,
 }
 
 ERRORS = {


### PR DESCRIPTION
When running in a serverless environment, there's a few things we want to keep in mind
1. long-running daemon threads are a bad idea given the ephemeral nature of the serverless environment
2. For a lambda-esque setup where the serverless run is quick and thin, expensive initialization calls are also a bad idea

So to enable running in a serverless environment, this PR adds 2 new features
- a `useRemoteConfig` flag that defaults to `True`. By setting this to `False`, the client will not request a remote config from supergood. This solves (2) above
- a `runThreads` flag that defaults to `True`. By setting this to `False`, we will not spin up threads to pull the remote config intermittently or to flush intermittently. Flushing will have to be done manually instead. This solves (1) above

While there is more needed to run Supergood in these environments, these changes should still allow us to track in them.