### PR TITLE
Add sftp tracking support

### DIFF
--- a/src/supergood/client.py
+++ b/src/supergood/client.py
@@ -28,6 +28,7 @@ from .vendors.http import patch as patch_http
 from .vendors.httpx import patch as patch_httpx
 from .vendors.requests import patch as patch_requests
 from .vendors.urllib3 import patch as patch_urllib3
+from .vendors.paramiko import patch as patch_paramiko
 
 load_dotenv()
 
@@ -110,6 +111,7 @@ class Client(object):
         patch_http(self._cache_request, self._cache_response)
         patch_aiohttp(self._cache_request, self._cache_response)
         patch_httpx(self._cache_request, self._cache_response)
+        patch_paramiko(self._cache_request, self._cache_response)
 
         self.flush_thread = RepeatingThread(
             self.flush_cache, self.base_config["flushInterval"] / 1000

--- a/src/supergood/vendors/paramiko.py
+++ b/src/supergood/vendors/paramiko.py
@@ -10,16 +10,33 @@ SFTP_ERROR_CODE = 500
 SFTP_GET = 'GET'
 SFTP_PUT = 'PUT'
 
+def get_remote_url(hostname, port, remotepath):
+    return str('sftp://' + hostname + ':' + str(port) + remotepath)
+
+def safe_get_size(localpath):
+    try:
+        return os.stat(localpath).st_size
+    except FileNotFoundError:
+        return None
+
+def safe_get_hostname_and_port(sftp_client):
+    try:
+        hostname, port = sftp_client.get_channel().get_transport().sock.getpeername()
+    except Exception:
+        hostname, port = None, None
+    return hostname, port
+
 def patch(cache_request, cache_response):
-    _original_get = paramiko.SFTPFile.get
-    _original_put = paramiko.SFTPFile.put
+    _original_get = paramiko.sftp_client.SFTPClient.get
+    _original_put = paramiko.sftp_client.SFTPClient.put
 
     def _wrap_get(self, remotepath, localpath, callback=None, prefetch=True, max_concurrent_prefetch_requests=None):
+        hostname, port = safe_get_hostname_and_port(self)
         request_id = str(uuid4())
-        size = os.stat(localpath).st_size
+        size = safe_get_size(localpath)
         cache_request(
             request_id,
-            str(remotepath),
+            get_remote_url(hostname, port, remotepath),
             SFTP_GET,
             {
                 "remote_path": remotepath,
@@ -28,25 +45,34 @@ def patch(cache_request, cache_response):
             },
             {}
         )
+
         try:
             _original_get(self, remotepath, localpath, callback, prefetch, max_concurrent_prefetch_requests)
         except Exception as e:
             # Log error in Supergood
-            cache_response(request_id, None, None, SFTP_ERROR_CODE, repr(e))
+            cache_response(request_id, {}, {}, SFTP_ERROR_CODE, repr(e))
             raise e
-        cache_response(request_id, None, None, SFTP_SUCCESS_CODE, None)
+
+        cache_response(request_id, {}, {}, SFTP_SUCCESS_CODE, None)
 
     def _wrap_put(self, localpath, remotepath, callback=None, confirm=True):
+        hostname, port = safe_get_hostname_and_port(self)
         request_id = str(uuid4())
-        cache_request(request_id, str(remotepath), SFTP_PUT, None, None)
+        cache_request(request_id, get_remote_url(hostname, port, remotepath), SFTP_PUT, {}, {})
+        response_body = {
+            "local_path": localpath,
+            "remote_path": remotepath,
+        }
         try:
             sftp_attrs = _original_put(self, localpath, remotepath, callback, confirm)
+            response_body['size'] = sftp_attrs.st_size
         except Exception as e:
             # Log error in Supergood
-            cache_response(request_id, None, None, SFTP_ERROR_CODE, repr(e))
+            cache_response(request_id, response_body, {}, SFTP_ERROR_CODE, repr(e))
             raise e
-        cache_response(request_id, None, None, SFTP_SUCCESS_CODE, repr(sftp_attrs))
+
+        cache_response(request_id, response_body, {}, SFTP_SUCCESS_CODE, repr(sftp_attrs))
         return sftp_attrs
 
-    paramiko.SFTPFile.get = _wrap_get
-    paramiko.SFTPFile.put = _wrap_put
+    paramiko.sftp_client.SFTPClient.get = _wrap_get
+    paramiko.sftp_client.SFTPClient.put = _wrap_put

--- a/src/supergood/vendors/paramiko.py
+++ b/src/supergood/vendors/paramiko.py
@@ -1,0 +1,52 @@
+from uuid import uuid4
+
+import paramiko
+import os
+
+from ..constants import REQUEST_ID_KEY
+
+SFTP_SUCCESS_CODE = 200
+SFTP_ERROR_CODE = 500
+SFTP_GET = 'GET'
+SFTP_PUT = 'PUT'
+
+def patch(cache_request, cache_response):
+    _original_get = paramiko.SFTPFile.get
+    _original_put = paramiko.SFTPFile.put
+
+    def _wrap_get(self, remotepath, localpath, callback=None, prefetch=True, max_concurrent_prefetch_requests=None):
+        request_id = str(uuid4())
+        size = os.stat(localpath).st_size
+        cache_request(
+            request_id,
+            str(remotepath),
+            SFTP_GET,
+            {
+                "remote_path": remotepath,
+                "local_path": localpath,
+                "size": size
+            },
+            {}
+        )
+        try:
+            _original_get(self, remotepath, localpath, callback, prefetch, max_concurrent_prefetch_requests)
+        except Exception as e:
+            # Log error in Supergood
+            cache_response(request_id, None, None, SFTP_ERROR_CODE, repr(e))
+            raise e
+        cache_response(request_id, None, None, SFTP_SUCCESS_CODE, None)
+
+    def _wrap_put(self, localpath, remotepath, callback=None, confirm=True):
+        request_id = str(uuid4())
+        cache_request(request_id, str(remotepath), SFTP_PUT, None, None)
+        try:
+            sftp_attrs = _original_put(self, localpath, remotepath, callback, confirm)
+        except Exception as e:
+            # Log error in Supergood
+            cache_response(request_id, None, None, SFTP_ERROR_CODE, repr(e))
+            raise e
+        cache_response(request_id, None, None, SFTP_SUCCESS_CODE, repr(sftp_attrs))
+        return sftp_attrs
+
+    paramiko.SFTPFile.get = _wrap_get
+    paramiko.SFTPFile.put = _wrap_put


### PR DESCRIPTION
This change patches the paramiko library to support Supergood tracking in a similar fashion to the HTTP APIs we currently track. At the moment we only support tracking SFTP get/put with the following details:

- Remote Server + Port
- Local File
- Remote File
- Error Message (if errors are thrown)
- Size of File

Once the SFTP calls are in this format, we're able to process them like any every other HTTP API call.

Since SFTP calls do not traditionally have a method or a response code like HTTP, I have co-opted GET and PUT as well as 200 and 500 to represent the different functions and status codes, to ensure that all downstream Supergood applications work as expected.