### PR TITLE
Feature: Call tagging

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.1.7
+current_version = 1.1.8
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="supergood",
-    version="1.1.7",
+    version="1.1.8",
     author="Alex Klarfeld",
     description="The Python client for Supergood",
     long_description=long_description,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,6 +31,7 @@ def broken_client(broken_redaction, monkeysession):
         client_id="client_id",
         client_secret_id="client_secret_id",
         base_url="https://api.supergood.ai",
+        telemetry_url="https://telemetry.supergood.ai",
         config=config,
     )
     monkeysession.setenv("SG_OVERRIDE_AUTO_FLUSH", "false")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -70,6 +70,7 @@ def supergood_client(request, session_mocker, monkeysession):
         client_id="client_id",
         client_secret_id="client_secret_id",
         base_url="https://api.supergood.ai",
+        telemetry_url="https://telemetry.supergood.ai",
         config=config,
     )
     client._get_config()

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -114,6 +114,18 @@ class TestCore:
         session_mocker.patch("supergood.api.Api.post_events").start()
         supergood_client.kill()
 
+    def test_tagging(self, httpserver: HTTPServer, supergood_client):
+        with supergood_client.tagging({"key": "val"}):
+            requests.get(httpserver.url_for("/200"))
+
+        supergood_client.flush_cache()
+        assert Api.post_events.call_args is not None
+        args = Api.post_events.call_args[0][0]
+        assert args[0]["request"] is not None
+        assert args[0]["response"] is not None
+        assert args[0]["metadata"]["tags"] == {"key": "val"}
+        supergood_client.kill()
+
     def test_different_http_library(self, httpserver: HTTPServer, supergood_client):
         http = urllib3.PoolManager()
         http.request("GET", f"{TEST_BED_URL}/200")


### PR DESCRIPTION
The tagging feature can be used to add important context to the events you fire to supergood that may not be present in the request/response structure itself. Those tags will be applied to all calls made within the context manager. These can be made across threads without concern for tags bleeding across threads as well. In the following example:
```
with SGClient.tagging({'variant': 'treatment1'}):
    requests.get(url1)
    requests.get(url2)
requests.get(url3)
```
The event associated with url1 and url2 would have the treatment1 context available to it for data slicing. The url3 event would not have that context available