### PR TITLE
Introduce Singleton pattern

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.1.7
+current_version = 1.1.8
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="supergood",
-    version="1.1.7",
+    version="1.1.8",
     author="Alex Klarfeld",
     description="The Python client for Supergood",
     long_description=long_description,

--- a/src/supergood/client.py
+++ b/src/supergood/client.py
@@ -33,6 +33,13 @@ load_dotenv()
 
 
 class Client(object):
+    # Not incredibly pythonic, but makes this class a singleton
+    def __new__(cls, *args, **kwargs):
+        if not hasattr(cls, "instance"):
+            # Create client for first time
+            cls.instance = super(Client, cls).__new__(cls)
+        return cls.instance
+
     def __init__(
         self,
         client_id=os.getenv("SUPERGOOD_CLIENT_ID"),
@@ -42,6 +49,10 @@ class Client(object):
         config={},
         metadata={},
     ):
+        # Double initializing can cause double sends to Supergood
+        if hasattr(self, "main_pid"):
+            return
+
         # This PID is used to detect when the client is running in a forked process
         self.main_pid = os.getpid()
         self.base_url = base_url if base_url else DEFAULT_SUPERGOOD_BASE_URL

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -26,6 +26,10 @@ TEST_BED_URL = "http://supergood-testbed.herokuapp.com"
 
 
 class TestCore:
+    def test_singleton(self, supergood_client):
+        c2 = Client()
+        assert c2 is supergood_client
+
     def test_captures_all_outgoing_200_http_requests(
         self, httpserver: HTTPServer, supergood_client
     ):


### PR DESCRIPTION
With the new Supergood tagging feature, it may become necessary to import the client from another file in which it wasn't initialized. A Singleton pattern here would make the most sense, as all threads within the same process space should be using the same Client

However, Singleton patterns of this sort aren't really pythonic. The better way would be to utilize the fact that imported modules are singletons, and expose an instance of a Client class to be initialized/interacted with instead. However this would be a breaking change, and therefore should be included in the next major version patch.

In the interim, for now this seems to enforce that only a single instance of a class can exist within a process space. 