### PR TITLE
redact by default

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,6 +36,12 @@ jobs:
           pytest tests/test_ignored_domains.py
           pytest tests/test_remote_config.py
           pytest tests/test_repeating_thread.py
+          pytest tests/caching/test_location_request_body.py
+          pytest tests/caching/test_location_request_headers.py
           pytest tests/redaction/test_no_redaction.py
-          pytest tests/redaction/test_redaction.py
+          pytest tests/redaction/test_redact_all.py
           pytest tests/redaction/test_redact_arrays.py
+          pytest tests/redaction/test_redact_by_default.py
+          pytest tests/redaction/test_redaction_failures.py
+          pytest tests/redaction/test_redaction.py
+          pytest tests/redaction/test_top_level_redaction.py

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.1.7
+current_version = 1.1.8
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="supergood",
-    version="1.1.7",
+    version="1.1.8",
     author="Alex Klarfeld",
     description="The Python client for Supergood",
     long_description=long_description,

--- a/src/supergood/client.py
+++ b/src/supergood/client.py
@@ -350,7 +350,10 @@ class Client(object):
             try:
                 # In force redact all mode, always force redact everything
                 if self.base_config["forceRedactAll"]:
-                    redact_all(data)
+                    redact_all(data, self.remote_config, by_default=False)
+                # In redact by default mode, redact any non-allowed keys
+                elif self.base_config["redactByDefault"]:
+                    redact_all(data, self.remote_config, by_default=True)
                 # Otherwise, redact using the remote config in remote config mode
                 elif self.base_config["useRemoteConfig"]:
                     to_delete = redact_values(

--- a/src/supergood/constants.py
+++ b/src/supergood/constants.py
@@ -25,6 +25,7 @@ DEFAULT_SUPERGOOD_CONFIG = {
     "ignoreRedaction": False,  # ignores redaction. Lowest priority flag
     "useRemoteConfig": True,
     "runThreads": True,
+    "redactByDefault": False,
 }
 
 ERRORS = {

--- a/src/supergood/remote_config.py
+++ b/src/supergood/remote_config.py
@@ -12,7 +12,7 @@ class SensitiveKey:
     """
     Key-level config
     key_path: path of key to action on
-    action: 'REDACT' (redacts value) ('HASH' and 'IGNORE' not supported for now)
+    action: 'REDACT' (redacts value) 'ALLOW' (allows value in redactByDefault mode)
     """
 
     key_path: str
@@ -155,3 +155,27 @@ def parse_remote_config_json(
         remote_config[vendor_id] = vendor_config
 
     return remote_config
+
+
+def get_allowed_keys(remote_config, vendor_id, endpoint_id):
+    # log.debug("getting allowed keys")
+    vendor_config = remote_config.get(vendor_id, None)
+    if not vendor_config:
+        # log.debug("got null vendor config")
+        return []
+    endpoints = vendor_config.endpoints
+    if not endpoints:
+        # log.debug("got null endpoints")
+        return []
+    endpoint = endpoints.get(endpoint_id, None)
+    if not endpoint:
+        # log.debug("got null endpoint")
+        return []
+    sensitive_keys = endpoint.sensitive_keys
+    if not sensitive_keys:
+        # log.debug("no sensitive keys")
+        return []
+    filtered = list(filter(lambda x: x.action == "ALLOW", sensitive_keys))
+    mapped = list(map(lambda x: x.key_path, filtered))
+    # log.debug(mapped)
+    return mapped

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,6 +31,7 @@ def broken_client(broken_redaction, monkeysession):
         client_id="client_id",
         client_secret_id="client_secret_id",
         base_url="https://api.supergood.ai",
+        telemetry_url="https://telemetry.supergood.ai",
         config=config,
     )
     monkeysession.setenv("SG_OVERRIDE_AUTO_FLUSH", "false")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -70,6 +70,7 @@ def supergood_client(request, session_mocker, monkeysession):
         client_id="client_id",
         client_secret_id="client_secret_id",
         base_url="https://api.supergood.ai",
+        telemetry_url="https://telemetry.supergood.ai",
         config=config,
     )
     client._get_config()

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -7,7 +7,8 @@ def get_config(
     log_request_headers=True,
     log_response_body=True,
     log_response_headers=True,
-    force_redact_all=False,  # this is true by default in the config, but most tests want to test it off
+    force_redact_all=False,
+    redact_by_default=False,
 ):
     return {
         "flushInterval": flush_interval,
@@ -21,6 +22,7 @@ def get_config(
         "logResponseHeaders": log_response_headers,
         "logResponseBody": log_response_body,
         "forceRedactAll": force_redact_all,
+        "redactByDefault": redact_by_default,
     }
 
 

--- a/tests/redaction/test_redact_all.py
+++ b/tests/redaction/test_redact_all.py
@@ -1,0 +1,53 @@
+import pytest
+import requests
+
+from supergood.api import Api
+from tests.helper import get_config, get_remote_config
+
+
+@pytest.mark.parametrize(
+    "supergood_client",
+    [
+        {
+            "remote_config": get_remote_config(
+                keys=[
+                    ("responseBody.string", "ALLOW"),
+                    ("responseBody.other_string", "REDACT"),
+                ]
+            ),
+            "config": get_config(force_redact_all=True),
+        }
+    ],
+    indirect=True,
+)
+class TestRedactAll:
+    def test_redact_all(self, httpserver, supergood_client):
+        httpserver.expect_request("/200").respond_with_json(
+            {
+                "string": "abc",
+                "other_string": "123",
+            }
+        )
+        requests.get(httpserver.url_for("/200"))
+        supergood_client.flush_cache()
+        args = Api.post_events.call_args[0][0]
+        response_body = args[0]["response"]["body"]
+        metadata = args[0]["metadata"]
+        assert response_body["string"] == None  # redacted!
+        assert response_body["other_string"] == None  # redacted!
+        assert len(metadata["sensitiveKeys"]) > 0
+        # There are a bunch of request/response headers. Filter for just responseBody
+        filtered = list(
+            filter(
+                lambda x: x["keyPath"].startswith("responseBody"),
+                metadata["sensitiveKeys"],
+            )
+        )
+        assert len(filtered) == 2
+        for entry in filtered:
+            assert (
+                entry["keyPath"] == "responseBody.string"
+                or entry["keyPath"] == "responseBody.other_string"
+            )
+            assert entry["type"] == "string"
+            assert entry["length"] == 3

--- a/tests/redaction/test_redact_by_default.py
+++ b/tests/redaction/test_redact_by_default.py
@@ -1,0 +1,49 @@
+import pytest
+import requests
+
+from supergood.api import Api
+from tests.helper import get_config, get_remote_config
+
+
+@pytest.mark.parametrize(
+    "supergood_client",
+    [
+        {
+            "remote_config": get_remote_config(
+                keys=[
+                    ("responseBody.string", "ALLOW"),
+                    ("responseBody.other_string", "REDACT"),
+                ]
+            ),
+            "config": get_config(redact_by_default=True),
+        }
+    ],
+    indirect=True,
+)
+class TestRedactByDefault:
+    def test_redact_by_default(self, httpserver, supergood_client):
+        httpserver.expect_request("/200").respond_with_json(
+            {
+                "string": "abc",
+                "other_string": "123",
+            }
+        )
+        requests.get(httpserver.url_for("/200"))
+        supergood_client.flush_cache()
+        args = Api.post_events.call_args[0][0]
+        response_body = args[0]["response"]["body"]
+        metadata = args[0]["metadata"]
+        assert response_body["string"] == "abc"  # not redacted!
+        assert response_body["other_string"] == None  # redacted!
+        assert len(metadata["sensitiveKeys"]) > 0
+        # There are a bunch of request/response headers. Filter for just responseBody
+        filtered = list(
+            filter(
+                lambda x: x["keyPath"].startswith("responseBody"),
+                metadata["sensitiveKeys"],
+            )
+        )
+        assert len(filtered) == 1
+        assert filtered[0]["keyPath"] == "responseBody.other_string"
+        assert filtered[0]["type"] == "string"
+        assert filtered[0]["length"] == 3


### PR DESCRIPTION
This PR adds a new functionality to the supergood client called "redact by default"

We wanted a workflow where users could start by redacting everything, and then in the UI of the Supergood dashboard selectively allow only those keys they'd like supergood to be sent. This allows teams with highly sensitive data to be absolutely sure about what values are sent outside their server

Tests are coming, but wanted to get this pushed up for discussion