### PR TITLE
fix openai streaming

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,3 +45,4 @@ jobs:
           pytest tests/redaction/test_redaction_failures.py
           pytest tests/redaction/test_redaction.py
           pytest tests/redaction/test_top_level_redaction.py
+          pytest tests/vendors/test_httpx.py

--- a/src/supergood/client.py
+++ b/src/supergood/client.py
@@ -388,6 +388,7 @@ class Client(object):
                     # telemetry post is nice to have, if it fails just log and ignore
                     self.log.warning(f"Error posting telemetry: {e}")
                 self.api.post_events(data)
+                print(data)
         except Exception:
             trace = "".join(traceback.format_exc())
             payload = ""

--- a/src/supergood/client.py
+++ b/src/supergood/client.py
@@ -388,7 +388,6 @@ class Client(object):
                     # telemetry post is nice to have, if it fails just log and ignore
                     self.log.warning(f"Error posting telemetry: {e}")
                 self.api.post_events(data)
-                print(data)
         except Exception:
             trace = "".join(traceback.format_exc())
             payload = ""

--- a/src/supergood/helpers.py
+++ b/src/supergood/helpers.py
@@ -2,7 +2,6 @@ import gzip
 import hashlib
 import json
 import sys
-import traceback
 from base64 import b64encode
 from typing import Tuple
 
@@ -378,8 +377,15 @@ def safe_decode(input, encoding="utf-8"):
             return None
         if isinstance(input, bytes) and input[:2] == GZIP_START_BYTES:
             return gzip.decompress(input)
+        if isinstance(input, bytes):
+            return input.decode(encoding)
         if isinstance(input, str):
             return input
+        if isinstance(input, list) or isinstance(input, dict):
+            try:
+                return json.dumps(input)
+            except Exception:
+                return str(input)
         return input.decode(encoding)
     except Exception:
         return str(input)

--- a/src/supergood/helpers.py
+++ b/src/supergood/helpers.py
@@ -377,15 +377,8 @@ def safe_decode(input, encoding="utf-8"):
             return None
         if isinstance(input, bytes) and input[:2] == GZIP_START_BYTES:
             return gzip.decompress(input)
-        if isinstance(input, bytes):
-            return input.decode(encoding)
         if isinstance(input, str):
             return input
-        if isinstance(input, list) or isinstance(input, dict):
-            try:
-                return json.dumps(input)
-            except Exception:
-                return str(input)
         return input.decode(encoding)
     except Exception:
         return str(input)

--- a/src/supergood/vendors/helpers.py
+++ b/src/supergood/vendors/helpers.py
@@ -1,6 +1,6 @@
 import dataclasses
 import json
-from typing import List
+from typing import List, Optional
 
 
 class DataclassesJSONEncoder(json.JSONEncoder):
@@ -17,6 +17,6 @@ class ServerSentEvent:
     """
 
     event: str | None
-    data: List[str]
+    data: Optional[str]
     id: str | None
     retry: int | None

--- a/src/supergood/vendors/helpers.py
+++ b/src/supergood/vendors/helpers.py
@@ -16,7 +16,7 @@ class ServerSentEvent:
     Storage class for streamed server side events
     """
 
-    event: str | None
-    data: Optional[str]
-    id: str | None
-    retry: int | None
+    event: Optional[str]
+    data: List[str]
+    id: Optional[str]
+    retry: Optional[int]

--- a/src/supergood/vendors/helpers.py
+++ b/src/supergood/vendors/helpers.py
@@ -1,0 +1,22 @@
+import dataclasses
+import json
+from typing import List
+
+
+class DataclassesJSONEncoder(json.JSONEncoder):
+    def default(self, o):
+        if dataclasses.is_dataclass(o):
+            return dataclasses.asdict(o)
+        return super().default(o)
+
+
+@dataclasses.dataclass
+class ServerSentEvent:
+    """
+    Storage class for streamed server side events
+    """
+
+    event: str | None
+    data: List[str]
+    id: str | None
+    retry: int | None

--- a/src/supergood/vendors/httpx.py
+++ b/src/supergood/vendors/httpx.py
@@ -1,4 +1,5 @@
 import json
+from typing import Optional
 from uuid import uuid4
 
 import httpx
@@ -132,14 +133,14 @@ def patch(cache_request, cache_response):
         # if we got to the end but didn't get a dispatch instruction, sse was invalid
         return None
 
-    def _wrap_iter_bytes(response: httpx.Response):
+    def _wrap_iter_bytes(response: httpx.Response, chunk_size: Optional[int] = None):
         request_id = getattr(response, REQUEST_ID_KEY)
         status_text = response.extensions.get("reason_phrase", None)
         if status_text:
             status_text = status_text.decode("utf-8")
         response_chunks = []
         data = b""
-        for chunk in _original_response_iter_bytes(response):
+        for chunk in _original_response_iter_bytes(response, chunk_size):
             for line in chunk.splitlines(keepends=True):
                 data += line
                 if data.endswith((b"\r\r", b"\n\n", b"\r\n\r\n")):

--- a/src/supergood/vendors/httpx.py
+++ b/src/supergood/vendors/httpx.py
@@ -1,14 +1,17 @@
+import json
 from uuid import uuid4
 
 import httpx
 
 from ..constants import REQUEST_ID_KEY
+from .helpers import DataclassesJSONEncoder, ServerSentEvent
 
 
 def patch(cache_request, cache_response):
     _original_handle_request = httpx.HTTPTransport.handle_request
     _original_response_read = httpx.Response.read
     _original_response_iter_lines = httpx.Response.iter_lines
+    _original_response_iter_bytes = httpx.Response.iter_bytes
 
     _original_handle_async_request = httpx.AsyncHTTPTransport.handle_async_request
     _original_response_aread = httpx.Response.aread
@@ -92,9 +95,84 @@ def patch(cache_request, cache_response):
             status_text,
         )
 
+    def _parse_sse(chunk: str):
+        data = []
+        event = None
+        id = None
+        retry = None
+
+        for line in chunk.splitlines():
+            if not line:
+                # empty newline = dispatch
+                sse = ServerSentEvent(event, data, id, retry)
+                return sse
+            if line.startswith(":"):
+                return None
+            field, _, value = line.partition(":")
+            if value.startswith(" "):
+                value = value[1:]
+            if field == "event":
+                event = value
+            elif field == "data":
+                # parse the value as json if it's serializable. otherwise use a string
+                try:
+                    serialized = json.loads(value)
+                except:
+                    serialized = value
+                data.append(serialized)
+            elif field == "id":
+                if "\0" not in value:
+                    id = value
+            elif field == "retry":
+                try:
+                    retry = int(value)
+                except (TypeError, ValueError):
+                    # what do?
+                    pass
+        # if we got to the end but didn't get a dispatch instruction, sse was invalid
+        return None
+
+    def _wrap_iter_bytes(response: httpx.Response):
+        request_id = getattr(response, REQUEST_ID_KEY)
+        status_text = response.extensions.get("reason_phrase", None)
+        if status_text:
+            status_text = status_text.decode("utf-8")
+        response_chunks = []
+        data = b""
+        for chunk in _original_response_iter_bytes(response):
+            for line in chunk.splitlines(keepends=True):
+                data += line
+                if data.endswith((b"\r\r", b"\n\n", b"\r\n\r\n")):
+                    # assume it's an SSE response
+                    decoded = data.decode("utf-8")
+                    try:
+                        sse = _parse_sse(decoded)
+                        if sse:
+                            response_chunks.append(sse)
+                    except Exception:
+                        # failing SSE parsing, just return as string
+                        response_chunks.append(decoded)
+                    data = b""
+            yield chunk
+        if len(data):
+            # must have been an invalid chunk, append it anyway
+            response_chunks.append(data)
+        try:
+            response_body = json.dumps(response_chunks, cls=DataclassesJSONEncoder)
+        except Exception:
+            response_body = str(response_chunks)
+        cache_response(
+            request_id,
+            response_body,
+            response.headers,
+            response.status_code,
+            status_text,
+        )
+
     httpx.HTTPTransport.handle_request = _wrap_handle_request
     httpx.Response.read = _wrap_response_read
     httpx.Response.iter_lines = _wrap_iter_lines
+    httpx.Response.iter_bytes = _wrap_iter_bytes
 
     httpx.AsyncHTTPTransport.handle_async_request = _wrap_handle_async_request
     httpx.Response.aread = _wrap_response_aread

--- a/tests/vendors/test_httpx.py
+++ b/tests/vendors/test_httpx.py
@@ -1,0 +1,24 @@
+import httpx
+from pytest_httpserver import HTTPServer
+
+from supergood.api import Api
+
+
+class TestHttpx:
+    def test_httpx_streaming(self, httpserver: HTTPServer, supergood_client):
+        raw_response = 'data: {"valid": "json"}\n\ndata: [DONE]\n\n'
+        httpserver.expect_request("/stream").respond_with_data(
+            response_data=raw_response
+        )
+        resp = b""
+        with httpx.stream("GET", httpserver.url_for("/stream")) as s:
+            for data in s.iter_bytes(chunk_size=1):
+                resp += data
+        assert resp.decode("utf-8") == raw_response
+        supergood_client.flush_cache()
+        args = Api.post_events.call_args[0][0]
+        # verify 2 entries, one each for each response field
+        assert len(args[0]["response"]["body"]) == 2
+        # verifies valid JSON is indexible
+        assert args[0]["response"]["body"][0]["data"][0]["valid"] == "json"
+        supergood_client.kill()


### PR DESCRIPTION
OpenAI uses the HTTPX iter_bytes function to iterate through a response. We currently weren't patching that, so responses were getting dropped.

During the investigation we also had to make some decisions on how to represent streamed responses internally in such a way that we can correctly ingest the keys on the Supergood server side. This work is still ongoing.

Tests TODO