### PR TITLE
Feature: Endpoint Categorization including method

### DIFF
--- a/src/supergood/client.py
+++ b/src/supergood/client.py
@@ -154,6 +154,7 @@ class Client(object):
         host_domain,
         metadata,
         url=None,
+        method=None,
         request_body=None,
         request_headers=None,
     ):
@@ -179,6 +180,7 @@ class Client(object):
         vendor, endpoint = get_vendor_endpoint_from_config(
             self.remote_config,
             url=url,
+            method=method,
             request_body=request_body,
             request_headers=request_headers,
         )
@@ -200,10 +202,12 @@ class Client(object):
             )  # sometimes headers is not json serializable
             request["metadata"] = {}
             # Check that we should cache the request
+            parsed_method = safe_decode(method)
             if not self._should_ignore(
                 host_domain,
                 request["metadata"],  # we store endpoint id in metadata
                 url=url,
+                method=parsed_method,
                 request_body=body,
                 request_headers=safe_headers,
             ):
@@ -221,7 +225,7 @@ class Client(object):
                 )
                 request["request"] = {
                     "id": request_id,
-                    "method": safe_decode(method),
+                    "method": parsed_method,
                     "url": url,
                     "body": filtered_body,
                     "headers": filtered_headers,

--- a/src/supergood/helpers.py
+++ b/src/supergood/helpers.py
@@ -347,6 +347,7 @@ def redact_values(input_array, remote_config, base_config):
             _, endpoint = get_vendor_endpoint_from_config(
                 remote_config,
                 url=data["request"].get("url"),
+                method=data["request"].get("method"),
                 request_body=data["request"]["body"],
                 request_headers=data["request"]["headers"],
             )

--- a/src/supergood/remote_config.py
+++ b/src/supergood/remote_config.py
@@ -96,9 +96,11 @@ def get_vendor_endpoint_from_config(
     vendor_config = next(
         (vcfg for vcfg in remote_config.values() if vcfg.domain in search), None
     )
+    compare_method = method.lower() if method else None
 
     def match(endpoint):
-        return endpoint.method == method and endpoint.regex.search(
+        test_method = endpoint.method.lower() if endpoint.method else None
+        return test_method == compare_method and endpoint.regex.search(
             get_endpoint_test_val(
                 location=endpoint.location,
                 url=url,

--- a/tests/caching/test_method.py
+++ b/tests/caching/test_method.py
@@ -1,0 +1,39 @@
+import pytest
+import requests
+from pytest_httpserver import HTTPServer
+
+from supergood.api import Api
+from tests.helper import get_remote_config
+
+
+@pytest.mark.parametrize(
+    "supergood_client",
+    [{"remote_config": get_remote_config(action="Ignore", method="POST")}],
+    indirect=True,
+)
+class TestMethod:
+    def test_method_matching(self, httpserver: HTTPServer, supergood_client):
+        httpserver.expect_request("/200", "POST").respond_with_json(
+            {
+                "string": "abc",
+            }
+        )
+        httpserver.expect_request("/200", "GET").respond_with_json(
+            {
+                "string": "def",
+            }
+        )
+        response1 = requests.request(
+            method="post",
+            url=httpserver.url_for("/200"),
+        )
+        # First call is ignored due to matching the ignored POST methods
+        assert response1.json()["string"] == "abc"
+        supergood_client.flush_cache()
+        assert Api.post_events.call_args is None
+        response2 = requests.request(method="get", url=httpserver.url_for("/200"))
+        # Second call is cached and flushed because it does not match (i.e. is a new endpoint)
+        assert response2.json()["string"] == "def"
+        supergood_client.flush_cache()
+        args = Api.post_events.call_args[0][0]
+        assert len(args) == 1

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -30,7 +30,9 @@ def build_key(key_path, key_action="REDACT"):
     return {"keyPath": key_path, "action": key_action}
 
 
-def get_remote_config(action="Allow", keys=[], location="path", regex="200"):
+def get_remote_config(
+    action="Allow", keys=[], location="path", regex="200", method="GET"
+):
     built_keys = list(map(lambda tup: build_key(tup[0], tup[1]), keys))
     return [
         {
@@ -39,6 +41,7 @@ def get_remote_config(action="Allow", keys=[], location="path", regex="200"):
             "endpoints": [
                 {
                     "id": "endpoint-id",
+                    "method": method,
                     "matchingRegex": {"location": location, "regex": regex},
                     "endpointConfiguration": {
                         "action": action,

--- a/tests/test_remote_config.py
+++ b/tests/test_remote_config.py
@@ -19,6 +19,7 @@ class TestRemoteConfig:
         assert endpoint_config.location == "path"
         assert endpoint_config.action == "Allow"
         assert endpoint_config.sensitive_keys == []
+        assert endpoint_config.method == "GET"
 
     def test_client_ignores_before_config(self, httpserver, supergood_client):
         # Not a perfect way of simulating it but good enough

--- a/tests/test_remote_config.py
+++ b/tests/test_remote_config.py
@@ -19,7 +19,7 @@ class TestRemoteConfig:
         assert endpoint_config.location == "path"
         assert endpoint_config.action == "Allow"
         assert endpoint_config.sensitive_keys == []
-        assert endpoint_config.method == "GET"
+        assert endpoint_config.method.lower() == "get"
 
     def test_client_ignores_before_config(self, httpserver, supergood_client):
         # Not a perfect way of simulating it but good enough


### PR DESCRIPTION
Currently supergood endpoints are categorized using a regex pattern matched against a few options. However, for an endpoint that is queried using multiple methods (GET, POST, PATCH, etc) all these calls get conflated to the same endpoint.

There are some cases where this may be desired, but in general a POST and a GET to an endpoint should not be considered the same. This PR will now allow for an endpoint's method to be specified in the remote config. Calls must match both the regex and the endpoint method now to be considered a match.

Added unit test case, currently testing locally.