### PR TITLE
dont throw on every non-200 HTTP call

### DIFF
--- a/src/supergood/client.py
+++ b/src/supergood/client.py
@@ -294,7 +294,13 @@ class Client(object):
     def _get_config(self) -> None:
         try:
             raw_config = self.api.get_config()
-            self.remote_config = parse_remote_config_json(raw_config)
+            if raw_config is False:
+                # we failed to pull the config. A refetch will be attempted shortly
+                self.log.warning(
+                    "[Supergood] Config fetch timed out. Fetch will be retried"
+                )
+            else:
+                self.remote_config = parse_remote_config_json(raw_config)
         except Exception:
             if self.remote_config:
                 self.log.warning("Failed to update remote config")


### PR DESCRIPTION
Changes the API to not throw an error when receiving a non-200 status code. Instead only pushes a warning to the logging infra

We're making this change because a low level of failed posts is acceptable but may appear noisy when using monitoring solutions like Sentry and ask-for-forgiveness based programming. We're actively considering other approaches, but this seems like the most sensible currently.